### PR TITLE
85 Fix failing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       CXX: /usr/bin/g++-10
     steps:


### PR DESCRIPTION
Closes #85.

Recent push exposed an issue with documentation and coverage workflows.

This PR should fix the documentation issues. The changes were to:
- Update the checkout action version.
- Install MPICH.
- Make some ammendments to the fnial step wherein the `gh-pages` branch is updated.



The fix for the miniconda incubator issues in `coverage.yml` are within PR #81.