### PR TITLE
Client MPI communicator

### DIFF
--- a/src/c++/CMakeLists.txt
+++ b/src/c++/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # ------------------------------------------------------------------------------
-#  (c) Crown copyright 2022 Met Office. All rights reserved.
+#  (c) Crown copyright 2024 Met Office. All rights reserved.
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------

--- a/src/c++/hashvec_handler.cpp
+++ b/src/c++/hashvec_handler.cpp
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/hashvec_handler.h
+++ b/src/c++/hashvec_handler.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/mpi_context.cpp
+++ b/src/c++/mpi_context.cpp
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2023 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/mpi_context.h
+++ b/src/c++/mpi_context.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2023 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/src/c++/vernier.cpp
+++ b/src/c++/vernier.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/
@@ -46,6 +46,7 @@ meto::Vernier::TracebackEntry::TracebackEntry(
  *                                  duplicate and use the duplicate.
  *                                  Defaults to MPI_COMM_WORLD.
  */ 
+
 void meto::Vernier::init(MPI_Comm const client_comm_handle)
 {
 
@@ -88,6 +89,7 @@ void meto::Vernier::init(MPI_Comm const client_comm_handle)
  * @note   Clears hashtable and traceback information; frees duplicate
  *         MPI communicator.
  */ 
+
 void meto::Vernier::finalize()
 {
   if(mpi_context_.is_initialized()){

--- a/src/c++/vernier.h
+++ b/src/c++/vernier.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/src/c++/writer/multi.cpp
+++ b/src/c++/writer/multi.cpp
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/writer/multi.h
+++ b/src/c++/writer/multi.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/writer/writer.cpp
+++ b/src/c++/writer/writer.cpp
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c++/writer/writer.h
+++ b/src/c++/writer/writer.h
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- *  (c) Crown copyright 2021 Met Office. All rights reserved.
+ *  (c) Crown copyright 2024 Met Office. All rights reserved.
  *  The file LICENCE, distributed with this code, contains details of the terms
  *  under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/src/c/vernier_c.cpp
+++ b/src/c/vernier_c.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/src/f/vernier_mod.F90
+++ b/src/f/vernier_mod.F90
@@ -1,5 +1,5 @@
 !-------------------------------------------------------------------------------
-! (c) Crown copyright 2022 Met Office. All rights reserved.
+! (c) Crown copyright 2024 Met Office. All rights reserved.
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------

--- a/tests/unit_tests/c++/CMakeLists.txt
+++ b/tests/unit_tests/c++/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#  (c) Crown copyright 2022 Met Office. All rights reserved.
+#  (c) Crown copyright 2024 Met Office. All rights reserved.
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------

--- a/tests/unit_tests/c++/mpi_main.cpp
+++ b/tests/unit_tests/c++/mpi_main.cpp
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------------
- * Crown copyright 2023 Met Office. All rights reserved.
+ * Crown copyright 2024 Met Office. All rights reserved.
  * The file LICENCE, distributed with this code, contains details of the terms
  * under which the code may be used.
  * -----------------------------------------------------------------------------

--- a/tests/unit_tests/c++/test_callcount.cpp
+++ b/tests/unit_tests/c++/test_callcount.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_hashtable.cpp
+++ b/tests/unit_tests/c++/test_hashtable.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_hashtiming.cpp
+++ b/tests/unit_tests/c++/test_hashtiming.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_mpi_not_init.cpp
+++ b/tests/unit_tests/c++/test_mpi_not_init.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2023 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_profiler.cpp
+++ b/tests/unit_tests/c++/test_profiler.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_proftests.cpp
+++ b/tests/unit_tests/c++/test_proftests.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_recursion.cpp
+++ b/tests/unit_tests/c++/test_recursion.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2023 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/c++/test_regionname.cpp
+++ b/tests/unit_tests/c++/test_regionname.cpp
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------*\
- (c) Crown copyright 2022 Met Office. All rights reserved.
+ (c) Crown copyright 2024 Met Office. All rights reserved.
  The file LICENCE, distributed with this code, contains details of the terms
  under which the code may be used.
 \*----------------------------------------------------------------------------*/

--- a/tests/unit_tests/f/CMakeLists.txt
+++ b/tests/unit_tests/f/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-#  (c) Crown copyright 2022 Met Office. All rights reserved.
+#  (c) Crown copyright 2024 Met Office. All rights reserved.
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------

--- a/tests/unit_tests/f/test_vernier_mod.pf
+++ b/tests/unit_tests/f/test_vernier_mod.pf
@@ -1,5 +1,5 @@
 !-------------------------------------------------------------------------------
-! (c) Crown copyright 2022 Met Office. All rights reserved.
+! (c) Crown copyright 2024 Met Office. All rights reserved.
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Allow client codes to set the MPI communicator used within Vernier.  This is needed to allow one component of a model to use Vernier.   [All components using Vernier simultaneously would need further work, since they'd all be trying to write to the same output filenames. See #116 ] 

Changes:
  * Create an `MPIContext` class and pass that where necessary. Ensures that we have all information passed around we need, plus somewhere to put additional functionality / checks.
  * Global Vernier object now has `init` and `finalize` methods.   Need somewhere to do MPI communicator duplication and free the communicator duplicate before the Vernier object goes out of scope.   Also allows Vernier to be reset.
  * Most C++ and Fortran tests now use MPI, if that only means that MPI is initialised.  There are some C++ tests that don't use MPI. They're there to check that a sensible controlled errors happen, rather than just seg-faulting.
  * I've taken away the default of `MPI_COMM_WORLD`. The major argument for keeping it was for legacy use by the one client code that has Vernier built-in at this point. Better to change the call in the client code at the next release.
