### PR TITLE
104 output raw total time

### DIFF
--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -184,7 +184,7 @@ void meto::Formatter::drhook(std::ofstream& os, hashvec_t hashvec)
       << std::setw(7)  << std::right << percent_time
       << std::setw(13) << std::right << cumul_walltime.count()
       << std::setw(13) << std::right << record.self_walltime_.count()
-      << std::setw(13) << std::right << record.total_walltime_.count()
+      << std::setw(13) << std::right << record.total_raw_walltime_.count()
       << std::setw(15) << std::right << record.call_count_
       << std::setw(12) << std::right << self_per_call
       << std::setw(12) << std::right << total_per_call       << "    "


### PR DESCRIPTION
I changed the DrHook output style to output the raw total time, not including time spent in the callipers. This change was made in the formatter.cpp file