### PR TITLE
Allow use of default MPI Communicator with Fortran API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Documentation for the project can be found [here](https://metoffice.github.io/Ve
 - C++17 compatible compiler.
 - CMake version 3.13 or newer.
 - GoogleTest version 1.11 or newer.
+- pFUnit version 4.4.1 or newer.
 
 ### Supported Compilers
 

--- a/cmake/TestingSetup.cmake
+++ b/cmake/TestingSetup.cmake
@@ -57,6 +57,10 @@ if(BUILD_TESTS)
         message(STATUS "Found pFUnit testing framework")
     endif()
 
+    # Set the MPI test executable name.
+    set(MPITEST_EXECUTABLE_NAME mpiexec)
+    set(MPIEXEC_NUMPROC_FLAG "-np")
+
     # Enable testing with CTest.
     enable_testing()
     add_subdirectory(tests)

--- a/src/c++/vernier.cpp
+++ b/src/c++/vernier.cpp
@@ -76,6 +76,10 @@ void meto::Vernier::init(MPI_Comm const client_comm_handle) {
   assert(static_cast<int>(thread_traceback_.size()) == max_threads_);
   assert(mpi_context_.is_initialized());
   assert(initialized_);
+#ifndef NDEBUG
+  std::cout << "Vernier Initialised with communicator handle: "
+            << client_comm_handle << std::endl;
+#endif
 }
 
 /**

--- a/src/c/vernier_c.cpp
+++ b/src/c/vernier_c.cpp
@@ -21,7 +21,7 @@
 #include <cstring>
 
 extern "C" {
-void c_vernier_init(const MPI_Fint* const client_comm_handle);
+void c_vernier_init(const MPI_Fint *const client_comm_handle);
 void c_vernier_finalize();
 void c_vernier_start_part1();
 void c_vernier_start_part2(long int &, char const *);
@@ -37,8 +37,7 @@ double c_vernier_get_wtime();
  * @param [in] client_comm_handle Fortran communicator handle.
  */
 
-void c_vernier_init(const MPI_Fint* const client_comm_handle)
-{
+void c_vernier_init(const MPI_Fint *const client_comm_handle) {
   MPI_Comm local_handle = MPI_COMM_WORLD;
   if (client_comm_handle) {
     local_handle = MPI_Comm_f2c(*client_comm_handle);

--- a/src/c/vernier_c.cpp
+++ b/src/c/vernier_c.cpp
@@ -18,11 +18,10 @@
 #include "vernier.h"
 #include "vernier_get_wtime.h"
 #include "vernier_mpi.h"
-
 #include <cstring>
 
 extern "C" {
-void c_vernier_init(MPI_Fint const &client_comm_handle);
+void c_vernier_init(const MPI_Fint* const client_comm_handle);
 void c_vernier_finalize();
 void c_vernier_start_part1();
 void c_vernier_start_part2(long int &, char const *);
@@ -35,13 +34,15 @@ double c_vernier_get_wtime();
 /**
  * @brief  Set a client-code-defined MPI communicator handle.
  * @details May be used to set other values in future, too.
- * @param [in] The Fortran communicator handle.
+ * @param [in] client_comm_handle Fortran communicator handle.
  */
 
-void c_vernier_init(MPI_Fint const &client_comm_handle)
-
+void c_vernier_init(const MPI_Fint* const client_comm_handle)
 {
-  MPI_Comm local_handle = MPI_Comm_f2c(client_comm_handle);
+  MPI_Comm local_handle = MPI_COMM_WORLD;
+  if (client_comm_handle) {
+    local_handle = MPI_Comm_f2c(*client_comm_handle);
+  }
   meto::vernier.init(local_handle);
 }
 

--- a/src/f/vernier_mod.F90
+++ b/src/f/vernier_mod.F90
@@ -21,7 +21,7 @@ module vernier_mod
 
   !> The real kind for region timings.
   integer, public, parameter :: vrk = c_double
-  
+
   !-----------------------------------------------------------------------------
   ! Public interfaces / subroutines
   !-----------------------------------------------------------------------------
@@ -32,7 +32,7 @@ module vernier_mod
   public :: vernier_stop
   public :: vernier_write
   public :: vernier_get_total_walltime
-  public :: vernier_get_wtime 
+  public :: vernier_get_wtime
 
   !-----------------------------------------------------------------------------
   ! Interfaces
@@ -42,7 +42,7 @@ module vernier_mod
 
     subroutine vernier_init(client_comm_handle)  &
                bind(C, name='c_vernier_init')
-      integer, intent(in) :: client_comm_handle
+      integer, optional, intent(in) :: client_comm_handle
     end subroutine vernier_init
 
     subroutine vernier_finalize() bind(C, name='c_vernier_finalize')
@@ -117,7 +117,7 @@ module vernier_mod
     !> @brief  Adds a null character to the end of a string.
     !> @param [in]  strlen      Length of the unterminated string.
     !> @param [in]  string_in   Unterminated string.
-    !> @param [out] string_out  Null-terminated string. 
+    !> @param [out] string_out  Null-terminated string.
     !> @note  Tests suggested that adding the null character in this manner, as
     !>     opposed to the concatenation operator (//) has performance benefits.
     subroutine append_null_char(string_in, string_out, strlen)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,3 +4,4 @@
 #  under which the code may be used.
 # ------------------------------------------------------------------------------
 add_subdirectory(unit_tests)
+add_subdirectory(system_tests)

--- a/tests/system_tests/CMakeLists.txt
+++ b/tests/system_tests/CMakeLists.txt
@@ -3,3 +3,4 @@
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------
+add_subdirectory(f)

--- a/tests/system_tests/f/CMakeLists.txt
+++ b/tests/system_tests/f/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------------
+#  (c) Crown copyright 2025 Met Office. All rights reserved.
+#  The file LICENCE, distributed with this code, contains details of the terms
+#  under which the code may be used.
+# ------------------------------------------------------------------------------
+
+if (BUILD_FORTRAN_TESTS)
+  # Function to simplify adding system-tests
+  function(add_fortran_system_test test_name source_file ranks)
+    set(TESTNAME_PREFIX "SystemTests")
+    message(STATUS "Building ${TESTNAME_PREFIX}.${test_name}")
+    add_executable(${TESTNAME_PREFIX}_${test_name} ${source_file})
+    target_link_libraries(${TESTNAME_PREFIX}_${test_name} ${CMAKE_PROJECT_NAME}_f)
+    target_include_directories(${TESTNAME_PREFIX}_${test_name} PUBLIC ${CMAKE_BINARY_DIR}/src/f/modules)
+    add_test(NAME ${TESTNAME_PREFIX}.${test_name}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND ${MPITEST_EXECUTABLE_NAME} ${MPIEXEC_NUMPROC_FLAG} ${ranks} $<TARGET_FILE:${TESTNAME_PREFIX}_${test_name}>
+    )
+  endfunction()
+
+  add_fortran_system_test(TestInitialisation test_initialisation.F90 2)
+endif ()

--- a/tests/system_tests/f/test_initialisation.F90
+++ b/tests/system_tests/f/test_initialisation.F90
@@ -27,6 +27,6 @@ program test_initialisation
   call vernier_stop(hash_out)
 
   Call vernier_finalize()
-
+call mpi_finalize(ierr)
 
 end program test_initialisation

--- a/tests/system_tests/f/test_initialisation.F90
+++ b/tests/system_tests/f/test_initialisation.F90
@@ -3,7 +3,10 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
-
+! A system test to allow checking that initialising the Fortran interface
+! without a communicator works and picks up the default communicator for
+! Vernier. This doesn't work as a unit test due to the way MPI is used in
+! pFUnit.
 program test_initialisation
   use vernier_mod, only: vik, &
                          vernier_init, vernier_finalize, &
@@ -26,7 +29,9 @@ program test_initialisation
   call sleep(1)
   call vernier_stop(hash_out)
 
-  Call vernier_finalize()
-call mpi_finalize(ierr)
+  call vernier_finalize()
+
+  call mpi_finalize(ierr)
 
 end program test_initialisation
+

--- a/tests/system_tests/f/test_initialisation.F90
+++ b/tests/system_tests/f/test_initialisation.F90
@@ -1,0 +1,32 @@
+!-------------------------------------------------------------------------------
+! (c) Crown copyright 2025 Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-------------------------------------------------------------------------------
+
+program test_initialisation
+  use vernier_mod, only: vik, &
+                         vernier_init, vernier_finalize, &
+                         vernier_start, vernier_stop
+  use mpi
+
+  implicit none
+
+  integer :: ierr
+  integer(vik) :: hash_out
+
+  ! Initialise MPI (Must happen before initialising Vernier)
+  call MPI_Init(ierr)
+
+  ! Initialise Vernier with the default communicator (i.e. pass no communicator)
+  call vernier_init()
+
+  call vernier_start(hash_out, "test_initialisation")
+  ! Do some work here
+  call sleep(1)
+  call vernier_stop(hash_out)
+
+  Call vernier_finalize()
+
+
+end program test_initialisation

--- a/tests/unit_tests/c++/CMakeLists.txt
+++ b/tests/unit_tests/c++/CMakeLists.txt
@@ -35,7 +35,7 @@ endfunction()
 
 # List of unit-tests added to CTest. Add a line calling the 'add_unit_test'
 # function to add an additional file of tests.
-add_unit_test(test_profiler test_profiler.cpp)
+add_unit_test(test_profiler test_timing.cpp)
 add_unit_test(test_hashtiming test_hashtiming.cpp)
 add_unit_test(test_regionname test_regionname.cpp)
 add_unit_test(test_hashtable test_hashtable.cpp)

--- a/tests/unit_tests/c++/test_mpi_not_init.cpp
+++ b/tests/unit_tests/c++/test_mpi_not_init.cpp
@@ -12,7 +12,7 @@
 using ::testing::ExitedWithCode;
 
 // Attempt to initialise Vernier without MPI being initialized.
-TEST(TestMPINotInit, MpiNotInitialised) {
+TEST(MPINotInitTest, MpiNotInitialised) {
 
   // clang-format off
 #ifdef USE_MPI

--- a/tests/unit_tests/c++/test_proftests.cpp
+++ b/tests/unit_tests/c++/test_proftests.cpp
@@ -17,11 +17,11 @@
 using ::testing::ExitedWithCode;
 
 //
-//  Tests and death tests related to profiler class members.
+//  Tests and death tests related to Vernier class members.
 //
 
 // Make sure the code exits when a hash mismatch happens.
-TEST(ProfilerDeathTest, WrongHashTest) {
+TEST(DeathTest, WrongHashTest) {
 
   meto::vernier.init();
 
@@ -34,7 +34,7 @@ TEST(ProfilerDeathTest, WrongHashTest) {
         const auto &prof_sub = meto::vernier.start("Vanilla");
         meto::vernier.stop(prof_sub);
 
-        // Wrong hash in profiler.stop()
+        // Wrong hash in Vernier.stop()
         meto::vernier.stop(prof_sub);
 
         // Eventually stop prof_main to avoid Wunused telling me off...
@@ -46,13 +46,13 @@ TEST(ProfilerDeathTest, WrongHashTest) {
 }
 
 // Tests for a segfault when stopping before anything else.
-TEST(ProfilerDeathTest, StopBeforeStartTest) {
+TEST(DeathTest, StopBeforeStartTest) {
 
   EXPECT_EXIT(
       {
         const auto prof_main = std::hash<std::string_view>{}("Main");
 
-        // Stop the profiler before anything is done
+        // Stop Vernier before anything is done
         meto::vernier.stop(prof_main);
       },
       ExitedWithCode(EXIT_FAILURE),
@@ -60,7 +60,7 @@ TEST(ProfilerDeathTest, StopBeforeStartTest) {
 }
 
 // Vernier is not initialised before first start() call.
-TEST(ProfilerDeathTest, StartBeforeInit) {
+TEST(DeathTest, StartBeforeInit) {
   // clang-format off
   EXPECT_EXIT({ meto::vernier.start("MAIN"); }, ExitedWithCode(EXIT_FAILURE),
               "Vernier::start_part1. Vernier not initialised.");
@@ -69,7 +69,7 @@ TEST(ProfilerDeathTest, StartBeforeInit) {
 
 // MPI is initialised, but the passed communicator handle is
 // MPI_COMM_NULL.
-TEST(ProfilerDeathTest, NullCommunicatorPassed) {
+TEST(DeathTest, NullCommunicatorPassed) {
   [[maybe_unused]] int ierr;
 
   EXPECT_EXIT(
@@ -80,7 +80,7 @@ TEST(ProfilerDeathTest, NullCommunicatorPassed) {
 }
 
 // Check that uninitialised MPI is caught in the write functionality.
-TEST(ProfilerDeathTest, VernierUninitialisedInWrite) {
+TEST(DeathTest, VernierUninitialisedInWrite) {
 
   // No init() called yet, so MPI context not initialised.
   // clang-format off
@@ -91,7 +91,7 @@ TEST(ProfilerDeathTest, VernierUninitialisedInWrite) {
 
 // The traceback array is not a growable vector. Check that the code exits
 // when available array elements are exhausted.
-TEST(ProfilerDeathTest, TooManyTracebackEntries) {
+TEST(DeathTest, TooManyTracebackEntries) {
 
   meto::vernier.init();
 
@@ -110,7 +110,7 @@ TEST(ProfilerDeathTest, TooManyTracebackEntries) {
 }
 
 // Tests the correct io mode is set. If not set correctly it will exit.
-TEST(ProfilerDeathTest, InvalidIOModeTest) {
+TEST(DeathTest, InvalidIOModeTest) {
   EXPECT_EXIT(
       {
         meto::MPIContext mpi_context;

--- a/tests/unit_tests/c++/test_timing.cpp
+++ b/tests/unit_tests/c++/test_timing.cpp
@@ -13,7 +13,7 @@
 #include "vernier.h"
 #include "vernier_get_wtime.h"
 
-TEST(SystemTests, TimingTest) {
+TEST(SystemTest, TimingTest) {
 
   meto::vernier.init();
 

--- a/tests/unit_tests/f/CMakeLists.txt
+++ b/tests/unit_tests/f/CMakeLists.txt
@@ -3,13 +3,19 @@
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------
-if(BUILD_FORTRAN_TESTS)
-    # If build Fortran tests is on add tests
-    add_pfunit_ctest( TestVernierFortran
-            TEST_SOURCES test_vernier_mod.pf
-            LINK_LIBRARIES ${CMAKE_PROJECT_NAME}_f
-            MAX_PES 2
-            )
-    message(STATUS "${CMAKE_BINARY_DIR}/src/f/modules")
-    target_include_directories(TestVernierFortran PUBLIC ${CMAKE_BINARY_DIR}/src/f/modules)
-endif()
+if (BUILD_FORTRAN_TESTS)
+  # Function to simplify adding unit-tests
+  function(add_fortran_unit_test test_name pf_file)
+    set(TESTNAME_PREFIX "FortranAPITests")
+    message(STATUS "Building ${test_name}")
+    add_pfunit_ctest(${TESTNAME_PREFIX}.${test_name}
+        TEST_SOURCES ${pf_file}
+        LINK_LIBRARIES ${CMAKE_PROJECT_NAME}_f
+        MAX_PES 2
+    )
+    target_include_directories(${TESTNAME_PREFIX}.${test_name} PUBLIC ${CMAKE_BINARY_DIR}/src/f/modules)
+  endfunction()
+
+  add_fortran_unit_test(TestVernier test_vernier_mod.pf)
+
+endif ()


### PR DESCRIPTION
Although Vernier will use a default MPI communicator when called from the C++ API this has not been passed through to the Fortran API. Have added the capability here. 

I haven't been able to get the testing working using pFUnit, I'm not sure why, for some reason it hangs. I do know that pFUnit controls the MPI communicator and duplicates it, it does state in the source not to use MPI_COMM_WORLD outside the main pFUnit program [MpiContext.F90#L65](https://github.com/Goddard-Fortran-Ecosystem/pFUnit/blob/main/src/pfunit/core/MpiContext.F90#L65) so perhaps they are doing some thing that doesn't play well if we try to use MPI_COMM_WORLD for Vernier as well.

As it is I've created a simple system test to check the call without an argument works, we perhaps need a better mechanism for testing this at some point.

I've also done a bit of tidying up of all the test names.