### PR TITLE
Updating conda environment file

### DIFF
--- a/etc/conda/vernier-env.yml
+++ b/etc/conda/vernier-env.yml
@@ -8,3 +8,4 @@ dependencies:
   - pydata-sphinx-theme
   - sphinx-sitemap
   - sphinx-design
+  - pandas


### PR DESCRIPTION
Closes #169 
Added pandas to conda environment file, this is the only additional library needed for the post-processing script. Further libraries can be added when the relevant functionality is added to the script (eg matplotlib for plotting).

While this has just been added to the pre-existing environment file, it may be preferable to make a new environment specifically for post-processing.