### PR TITLE
Add pkg-config support to Vernier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ include(cmake/PreventInSourceBuilds.cmake)
 # project description. Also set the version of the library being built.
 project(vernier LANGUAGES CXX C Fortran
         DESCRIPTION "Met Office Vernier profiler"
-        VERSION 0.3.1)
+        VERSION 0.3.1
+        HOMEPAGE_URL "https://github.com/MetOffice/Vernier")
 
 # OpenMP required
 find_package(OpenMP 2.5 REQUIRED)
@@ -66,3 +67,5 @@ if(STRING_LENGTH)
     message(WARNING "Max caliper label length is too small - using 100")
   endif()
 endif()
+
+include(cmake/PkgConfig.cmake)

--- a/cmake/BuildOptions.cmake
+++ b/cmake/BuildOptions.cmake
@@ -18,3 +18,5 @@ endif()
 # Optional profiler string length
 option(STRING_LENGTH "Maximum identifer string length" 100)
 
+# Whether to create a vernier.pc pkgc-config file
+option(ENABLE_PKGCONFIG "Enable pkg-config support" ON)

--- a/cmake/PkgConfig.cmake
+++ b/cmake/PkgConfig.cmake
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------------------
+#  (c) Crown copyright 2025 Met Office. All rights reserved.
+#  The file LICENCE, distributed with this code, contains details of the terms
+#  under which the code may be used.
+# ------------------------------------------------------------------------------
+
+if(ENABLE_PKGCONFIG)
+  # Create and install a pkg-config file
+  message(STATUS "Generating a pkg-config file")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/share/pkgconfig/${PROJECT_NAME}.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/${PROJECT_NAME}.pc
+                 @ONLY)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/${PROJECT_NAME}.pc
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+endif()

--- a/share/pkgconfig/vernier.pc.in
+++ b/share/pkgconfig/vernier.pc.in
@@ -1,0 +1,10 @@
+Name: Vernier
+Version: @PROJECT_VERSION@
+Description: @PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Libs: -L${libdir} -lvernier -lvernier_c -lvernier_f
+Cflags: -I${includedir}


### PR DESCRIPTION
Use the magic of CMake to process a template that can be picked
up by pkg-config and used to pass flags to compilers and build
systems.