### PR TITLE
Python tidy post processing

### DIFF
--- a/post-processing/tests/test_cli_tools.py
+++ b/post-processing/tests/test_cli_tools.py
@@ -25,7 +25,7 @@ class TestCLITools(unittest.TestCase):
         self.test_data_kgo = (
             '|      Routine | Total Min(s) | Total Mean(s) | Total Max(s) | Self Min(s) | Self Mean(s) | Self Max(s) | Max no. calls |   % time | Time per call(s) |\n' +
             '| __test_app__ |        5.854 |        6.3465 |        6.839 |       2.583 |       2.5855 |       2.588 |             1 |  40.9825 |           6.3465 |\n' +
-            '| some_process |        2.077 |         2.573 |        3.069 |       2.023 |        2.516 |       3.009 |             2 |   39.277 |           1.2865 |\n'
+            '| some_process |        2.077 |         2.573 |        3.069 |       2.023 |        2.516 |       3.009 |             2 |   39.277 |           1.2865 |'
             )
         return super().setUp()
 

--- a/post-processing/vernier/lib/vernier_data.py
+++ b/post-processing/vernier/lib/vernier_data.py
@@ -47,8 +47,6 @@ class VernierCalliper():
         self.total_time = []
         self.n_calls = []
 
-        return
-
     def __len__(self):
         """
         Return None if caliper elements differ in length,
@@ -60,7 +58,7 @@ class VernierCalliper():
             result = len(self.time_percent)
         return result
 
-    def _get_rank_indices(self, rank: int):
+    def get_rank_indices(self, rank: int):
         """
         Return the indices of the data for a given rank.
 
@@ -84,7 +82,7 @@ class VernierCalliper():
             except ValueError:
                 return rank_indices
 
-    def _get_thread_indices(self, thread: int):
+    def get_thread_indices(self, thread: int):
         """
         Return the indices of the data for a given thread.
 
@@ -108,7 +106,7 @@ class VernierCalliper():
             except ValueError:
                 return thread_indices
 
-    def _filter_by_indices(self, indices: list[int]):
+    def filter_by_indices(self, indices: list[int]):
         """
         Return a new VernierCalliper containing only the entries corresponding
         to the provided indices.
@@ -142,16 +140,28 @@ class VernierCalliper():
         """
 
         return OrderedDict([
-            ("Routine",self.name), # calliper name
-            ("Total Min(s)", round(min(self.total_time), 5)),               # min total time across calls
-            ("Total Mean(s)", round(statistics.mean(self.total_time), 5)),   # mean total time across calls
-            ("Total Max(s)", round(max(self.total_time), 5)),               # max total time across calls
-            ("Self Min(s)", round(min(self.self_time), 5)),                # min self time across calls
-            ("Self Mean(s)", round(statistics.mean(self.self_time), 5)),    # mean self time across calls
-            ("Self Max(s)", round(max(self.self_time), 5)),                # max self time across calls
-            ("Max no. calls", max(self.n_calls)), # number of calls (should be the same for all entries, so just take the first)
-            ("% time", round(statistics.mean(self.time_percent), 5)), # mean percentage of time across calls
-            ("Time per call(s)", round(statistics.mean([t / n for t, n in zip(self.total_time, self.n_calls)]), 5)) # mean time per call
+            # calliper name
+            ("Routine",self.name),
+            # min total time across calls
+            ("Total Min(s)", round(min(self.total_time), 5)),
+            # mean total time across calls
+            ("Total Mean(s)", round(statistics.mean(self.total_time), 5)),
+            # max total time across calls
+            ("Total Max(s)", round(max(self.total_time), 5)),
+            # min self time across calls
+            ("Self Min(s)", round(min(self.self_time), 5)),
+            # mean self time across calls
+            ("Self Mean(s)", round(statistics.mean(self.self_time), 5)),
+            # max self time across calls
+            ("Self Max(s)", round(max(self.self_time), 5)),
+            # maximum number of calls
+            ("Max no. calls", max(self.n_calls)),
+            # mean percentage of time across calls
+            ("% time", round(statistics.mean(self.time_percent), 5)),
+            # mean time per call
+            ("Time per call(s)", round(statistics.mean([t / n for t, n in
+                                                        zip(self.total_time,
+                                                            self.n_calls)]), 5))
         ])
 
 
@@ -203,7 +213,7 @@ class VernierData():
         filtered_data = VernierData()
 
         # Filter data for a given calliper key
-        for timer in self.data.keys():
+        for timer, _ in self.data.items():
             if any(calliper_key in timer for calliper_key in calliper_keys):
                 filtered_data.data[timer] = self.data[timer]
 
@@ -228,9 +238,9 @@ class VernierData():
 
         # From reduce, grab all of the data and separate from the header keys
         header_pass=True
-        for calliper in self.data.keys():
+        for adata in self.data.values():
             reduce_row = []
-            reduce_dict=self.data[calliper].reduce()
+            reduce_dict = adata.reduce()
             # Work through each caliper key pair returned by reduce
             for caliper_key in reduce_dict:
                 # Append the keys data/value to the row
@@ -249,33 +259,34 @@ class VernierData():
 
         max_calliper_len = max([len(line[0]) for line in txt_table])
 
-        # Write to stdout if no path provided, otherwise write to file
-        if txt_path is None:
-            out = sys.stdout
-        else:
-            out = open(txt_path, 'w')
-
+        row_outputs = []
         # For each line in the text table, format the string to be written
         for row in txt_table:
             row_output_string=''
-            for index, column in enumerate(row):
+            for index, _ in enumerate(row):
                  # The first column, the caliper name uses the maximum size to align all lines
                 if index == 0:
-                    row_output_string=row_output_string+(
-                        '| {:>{}} '.format(row[0], max_calliper_len))
-                # Per each other element, align them to the header length, or where this is too small, 8
+                    row_output_string = row_output_string + (
+                        f'| {row[0]:>{max_calliper_len}} ')
+                # Per each other element, align them to the header length,
+                # or where this is too small, 8
                 else:
-                    row_output_string=row_output_string+(
-                        '| {:>{}} '.format(row[index], max(len(header_list[index]),8)))
-            row_output_string=row_output_string+'|\n'
-            
-            # Write the string
-            out.write(row_output_string)
+                    row_output_string = row_output_string + (
+                        f'| {row[index]:>{max(len(header_list[index]),8)}} ')
+            row_output_string = row_output_string + '|'
+            row_outputs.append(row_output_string)
 
-        if txt_path is not None:
-            out.close()
+        output_string = '\n'.join(row_outputs)
 
-    def get(self, calliper_key: str, rank: Optional[int] = None, thread: Optional[int] = None) -> Optional[VernierCalliper]:
+        # Write to stdout if no path provided, otherwise write to file
+        if txt_path is None:
+            sys.stdout.write(output_string)
+        else:
+            with open(txt_path, 'w', encoding="utf-8") as file_out:
+                file_out.write(output_string)
+
+    def get(self, calliper_key: str, rank: Optional[int] = None,
+            thread: Optional[int] = None) -> Optional[VernierCalliper]:
         """
         Return a VernierCalliper of the data for this calliper_key,
         or None if it does not exist.
@@ -295,17 +306,17 @@ class VernierData():
         # If rank ID given as argument, filter only data indices where rank data
         # matches the rank ID given as argument
         if rank is not None:
-            rank_indices = return_caliper._get_rank_indices(rank)
+            rank_indices = return_caliper.get_rank_indices(rank)
             if len(rank_indices) == 0:
                 return None
-            return_caliper = return_caliper._filter_by_indices(rank_indices)
+            return_caliper = return_caliper.filter_by_indices(rank_indices)
 
         # Same above but for thread ID
         if thread is not None:
-            thread_indices = return_caliper._get_thread_indices(thread)
+            thread_indices = return_caliper.get_thread_indices(thread)
             if len(thread_indices) == 0:
                 return None
-            return_caliper = return_caliper._filter_by_indices(thread_indices)
+            return_caliper = return_caliper.filter_by_indices(thread_indices)
 
         return return_caliper
 
@@ -389,11 +400,11 @@ class VernierDataCollation():
         """
         if label in self.vernier_data:
             raise ValueError(f'The label {label} already exists in this '
-                             f'collation. Please use a different label or '
-                             f'remove the existing entry.')
+                             'collation. Please use a different label or '
+                             'remove the existing entry.')
         if not isinstance(vernier_data, VernierData):
-            raise TypeError(f'The provided vernier_data is not a VernierData '
-                            f'object.')
+            raise TypeError('The provided vernier_data is not a VernierData '
+                            'object.')
         # Check for consistency
         self.internal_consistency(vernier_data)
         # Add the new data
@@ -424,7 +435,7 @@ class VernierDataCollation():
         # notImplemented enforce consistent sizing of members?? needed?
         callipers = []
         # Loop over VernierData objects
-        for _, vdata in self.vernier_data.items():
+        for vdata in self.vernier_data.values():
             # Get a list of the VernierData's callipers, sorted by name
             loop_callipers = sorted(list(vdata.data.keys()))
             # If no callipers checked yet, set these as the truth callipers
@@ -437,17 +448,17 @@ class VernierDataCollation():
                     # Note that this works both ways so all callipers not in the
                     # others list are included.
                     mismatched = set(loop_callipers) ^ set(callipers)
-                    raise ValueError(f'Inconsistent callipers in contents: '
+                    raise ValueError('Inconsistent callipers in contents: '
                                      f'{mismatched} detected as unmatched')
         if new_vernier_data is not None:
             if not isinstance(new_vernier_data, VernierData):
-                raise TypeError(f'The provided vernier_data is not a '
+                raise TypeError('The provided vernier_data is not a '
                                 'VernierData object.')
             check_callipers = sorted(list(new_vernier_data.data.keys()))
             if callipers and check_callipers != callipers:
                 # Extract callipers that were mismatched using Python XOR
                 mismatched = set(check_callipers) ^ set(callipers)
-                raise ValueError(f'Inconsistent callipers in new_vernier_data: '
+                raise ValueError('Inconsistent callipers in new_vernier_data: '
                                  f'{check_callipers} detected as unmatched')
 
     def calliper_list(self):
@@ -461,12 +472,13 @@ class VernierDataCollation():
         result = []
         self.internal_consistency()
 
-        for _, vdata in self.vernier_data.items():
+        for vdata in self.vernier_data.values():
             result = sorted(list(vdata.data.keys()))
             break
         return result
 
-    def get(self, calliper_key: str, rank: Optional[int] = None, thread: Optional[int] = None) -> Optional[VernierCalliper]:
+    def get(self, calliper_key: str, rank: Optional[int] = None,
+            thread: Optional[int] = None) -> Optional[VernierCalliper]:
         """
         Return a VernierCalliper of all the data from all collation members
         for this calliper_key, or None if it does not exist.
@@ -485,7 +497,7 @@ class VernierDataCollation():
             return None
         self.internal_consistency()
         results = VernierCalliper(calliper_key)
-        for _, vdata in self.vernier_data.items():
+        for vdata in self.vernier_data.values():
             data_to_add = vdata.get(calliper_key, rank, thread)
             if data_to_add is None:
                 continue

--- a/post-processing/vernier/lib/vernier_data.py
+++ b/post-processing/vernier/lib/vernier_data.py
@@ -6,12 +6,13 @@
 """
 Module for storing the VernierData and VernierCalliper classes.
 """
+
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 import statistics
 import sys
 from typing import Optional
-from collections import OrderedDict
 
 
 @dataclass(order=True)
@@ -49,7 +50,7 @@ class VernierCalliper():
 
     def __len__(self):
         """
-        Return None if caliper elements differ in length,
+        Return None if calliper elements differ in length,
         otherwise return element lengths.
         """
         result = None
@@ -223,7 +224,8 @@ class VernierData():
 
         return filtered_data
 
-    def write_txt_output(self, txt_path: Optional[Path] = None):
+    def write_txt_output(self, txt_path: Optional[Path] = None,
+                         sort_by = "Routine", sort_reverse = False):
         """
         Writes the Vernier data to a text output in a human-readable table
         format. If an output path is provided, the table is written to that
@@ -232,27 +234,46 @@ class VernierData():
         :param txt_path: The file path that the text output will be written to.
         :type txt_path: :py:class:`pathlib.Path`
 
+        :param str sort_by: The name of the field used to sort the txt output,
+                            default is `Routine`, the name of the calliper.
+
+        :param bool sort_reverse: Whether to reverse the sort defined by sort_by.
+
         """
         txt_table = []
         header_list = []
 
         # From reduce, grab all of the data and separate from the header keys
-        header_pass=True
+        header_pass = True
         for adata in self.data.values():
             reduce_row = []
             reduce_dict = adata.reduce()
-            # Work through each caliper key pair returned by reduce
-            for caliper_key in reduce_dict:
+            # Work through each calliper key pair returned by reduce
+            for calliper_key in reduce_dict:
                 # Append the keys data/value to the row
-                reduce_row.append(reduce_dict[caliper_key])
+                reduce_row.append(reduce_dict[calliper_key])
                 # On the first pass capture the key for later as headers
                 if header_pass:
-                    header_list.append(caliper_key)
+                    header_list.append(calliper_key)
+                else:
+                    if calliper_key not in header_list:
+                        raise ValueError(f'calliper key `{calliper_key}` appears'
+                                         f' in some data but not the first, '
+                                         'inconsistent callipers can lead to '
+                                         'undefined behaviour')
             txt_table.append(reduce_row)
             header_pass=False
 
-        # sort by calliper name
-        txt_table.sort(key=lambda x: x[0])
+        # sort using the provided sort_by and sort_reverse options
+        # default is sort by Routine name, for consistency of output.
+        if not isinstance(sort_reverse, bool):
+            raise TypeError(f'sort_reverse must be a bool, not `{type(sort_reverse)}`')
+        if sort_by not in header_list:
+            raise ValueError(f'sort_by `{sort_by}` not in '
+                             f'list of available headers:\n'
+                             f'{header_list}')
+        sort_n = header_list.index(sort_by)
+        txt_table.sort(key=lambda x: x[sort_n], reverse=sort_reverse)
 
         # Use the header key to add to the top of the output
         txt_table.insert(0, header_list)
@@ -264,7 +285,7 @@ class VernierData():
         for row in txt_table:
             row_output_string=''
             for index, _ in enumerate(row):
-                 # The first column, the caliper name uses the maximum size to align all lines
+                 # The first column, the calliper name uses the maximum size to align all lines
                 if index == 0:
                     row_output_string = row_output_string + (
                         f'| {row[0]:>{max_calliper_len}} ')
@@ -301,24 +322,24 @@ class VernierData():
         :rtype: :py:class:`vernier.VernierCalliper`
         """
         # First get data for calliper key
-        return_caliper = self.data[calliper_key]
+        return_calliper = self.data[calliper_key]
 
         # If rank ID given as argument, filter only data indices where rank data
         # matches the rank ID given as argument
         if rank is not None:
-            rank_indices = return_caliper.get_rank_indices(rank)
+            rank_indices = return_calliper.get_rank_indices(rank)
             if len(rank_indices) == 0:
                 return None
-            return_caliper = return_caliper.filter_by_indices(rank_indices)
+            return_calliper = return_calliper.filter_by_indices(rank_indices)
 
         # Same above but for thread ID
         if thread is not None:
-            thread_indices = return_caliper.get_thread_indices(thread)
+            thread_indices = return_calliper.get_thread_indices(thread)
             if len(thread_indices) == 0:
                 return None
-            return_caliper = return_caliper.filter_by_indices(thread_indices)
+            return_calliper = return_calliper.filter_by_indices(thread_indices)
 
-        return return_caliper
+        return return_calliper
 
     def aggregate(self, vernier_data_list=None, internal_consistency=True):
         """

--- a/post-processing/vernier/lib/vernier_data.py
+++ b/post-processing/vernier/lib/vernier_data.py
@@ -251,8 +251,8 @@ class VernierData():
             txt_table.append(reduce_row)
             header_pass=False
 
-        # sort by self time, descending
-        txt_table = sorted(txt_table, key=lambda x: x[2], reverse=True)
+        # sort by calliper name
+        txt_table.sort(key=lambda x: x[0])
 
         # Use the header key to add to the top of the output
         txt_table.insert(0, header_list)

--- a/post-processing/vernier/lib/vernier_reader.py
+++ b/post-processing/vernier/lib/vernier_reader.py
@@ -3,6 +3,10 @@
 #  The file LICENCE, distributed with this code, contains details of the terms
 #  under which the code may be used.
 # ------------------------------------------------------------------------------
+"""
+Module for reading the Vernier text formats from files.
+"""
+
 from concurrent import futures
 from enum import Enum, auto
 from pathlib import Path
@@ -52,10 +56,10 @@ class VernierReader():
 
         if "region_name@thread_id" in file_header:
             return VernierFileFormat.THREADS
-        elif any([line.startswith('Profiling on') for line in file_header]):
+        if any([line.startswith('Profiling on') for line in file_header]):
             return VernierFileFormat.DRHOOK
-        else:
-            return VernierFileFormat.INVALID
+        # else
+        return VernierFileFormat.INVALID
 
     def _parse_threadsfile_data(self, file_contents: list[str]) -> VernierData:
         """
@@ -117,7 +121,8 @@ class VernierReader():
                 if calliper_data_section:
                     for key in pc_self_times.keys():
                         calliper = key.split('@')[0]
-                        loaded.data[calliper].time_percent.append((pc_self_times[key]/max_tot_time)*100)
+                        loaded.data[calliper].time_percent.append(
+                            (pc_self_times[key]/max_tot_time)*100)
                 calliper_data_section = False
 
         if not loaded.data:
@@ -227,9 +232,9 @@ class VernierReader():
         if self.path.is_file():
             return self._load_from_file()
 
-        elif self.path.is_dir():
+        if self.path.is_dir():
             return self._load_from_directory()
 
-        else:
-            raise ValueError(f"Provided path '{self.path}' is neither a file "
-                             f"nor a directory.")
+        # else
+        raise ValueError(f"Provided path '{self.path}' is neither a file "
+                         f"nor a directory.")


### PR DESCRIPTION
# Description

<!-- 
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. 
If there is additional detail included in the linked issue please note that here so a reviewer knows to check.      
-->

Some user feedback that sorting `by self time, descending` is confusing, and limiting to human readability and comparison, particularly as a default behaviour.

sort by calliper name is actually quite similar to the legacy timer tool, not exactly the same, but usable.
But, more importantly, it is consistent across runs, which is important.

Additionally a whole set of python style and programming model changes, identified in #237 and deferred

## Linked issues

Closes # (issue) <!-- Can be of the following forms Close/s/d #123 Fix/es/ed #123 or Resolve/s/d #123 (e.g. Closes #123) -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] New tests have been added
- [x] Tests have been modified to accommodate this change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes, for both debug and optimised builds

