### PR TITLE
Remove rogue SHARED from Fortran library setup

### DIFF
--- a/src/f/CMakeLists.txt
+++ b/src/f/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
 # Testing for building a fortran lib and executable.
-add_library(${CMAKE_PROJECT_NAME}_f SHARED "vernier_mod.F90")
+add_library(${CMAKE_PROJECT_NAME}_f "vernier_mod.F90")
 
 set(PLIBS OpenMP::OpenMP_Fortran)
 if (ENABLE_MPI)


### PR DESCRIPTION
# Description

The Fortran interface library does not respect the `BUILD_SHARED_LIBS` setting and always create a shared version.  This removes a rogue keyword from the library definition to make the behaviour consistent with the C++ library.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] New tests have been added
- [ ] Tests have been modified to accommodate this change

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes, for both debug and optimised builds

