### PR TITLE
Output version

### DIFF
--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -44,9 +44,9 @@ meto::Formatter::Formatter() {
 /**
  * @brief  Executes the format_ method to write the data.
  *
- * @param[inout] header   Output stream for the format header
- * @param[inout] os       Output stream that the format method will write data to
- * @param[in]    hashvec  Vector of data that the format method will operate on
+ * @param[inout] header  Output stream for the format header
+ * @param[inout] os      Output stream for the format method will write data to
+ * @param[in]    hashvec Vector of data that the format method will operate on
  */
 
 void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,

--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -19,20 +19,23 @@
 
 meto::Formatter::Formatter() {
 
-  std::string format = "drhook";
+  // Default formatter
+  std::string format = "default";
 
   char const *env_format = std::getenv("VERNIER_OUTPUT_FORMAT");
   if (env_format) {
     format = env_format;
   }
 
-  if (format == "threads") {
-    format_ = &Formatter::threads;
+  if (format == "default") {
+    format_ = &Formatter::default_output;
+    format_string_ = "Default";
   } else if (format == "drhook") {
     format_ = &Formatter::drhook;
+    format_string_ = "Dr HOOK";
   } else {
     std::string error_msg = "Invalid Vernier output format choice. Expected "
-                            "'threads' or 'drhook'. Currently set to '" +
+                            "'default' or 'drhook'. Currently set to '" +
                             format + "'.";
     error_handler(error_msg, EXIT_FAILURE);
   }
@@ -41,18 +44,14 @@ meto::Formatter::Formatter() {
 /**
  * @brief  Executes the format_ method to write the data.
  *
- * @param[in] os       Output stream that the format method will write to
+ * @param[in] header   Output stream for the format header
+ * @param[in] os       Output stream that the format method will write data to
  * @param[in] hashvec  Vector of data that the format method will operate on
  */
 
-void meto::Formatter::execute_format(std::ostream &os, hashvec_t hashvec,
-                                     MPIContext &mpi_context) {
-  // Add an MPI task identifier to each output file
-  os << "\n"
-     << "Task " << (mpi_context.get_rank() + 1) << " of "
-     << mpi_context.get_size() << " : MPI rank ID " << mpi_context.get_rank()
-     << "\n";
-  (this->*format_)(os, hashvec);
+void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,
+                                     const hashvec_t &hashvec) {
+  (this->*format_)(header, os, hashvec);
 }
 
 /**
@@ -62,37 +61,39 @@ void meto::Formatter::execute_format(std::ostream &os, hashvec_t hashvec,
  * @param[in] hashvec  Vector containing all the necessary data
  */
 
-void meto::Formatter::threads(std::ostream &os, hashvec_t hashvec) {
+void meto::Formatter::default_output(std::ostream &header, std::ostream &os,
+                              const hashvec_t &hashvec) {
 
   // Write key
-  os << "\n";
-  os << "region_name@thread_id\n"
-     << "Self time : Time accrued by region itself. (Exclusive time.)\n"
-     << "Total time: Time including cost of child routines and profiling "
-        "overheads. (Inclusive time.)\n"
-     << "Overhead  : Profiling overhead incurred through direct child routine "
-        "calls only.\n"
-     << "Calls     : Number of times the region is called.\n";
+  header << "\n";
+  header << "region_name@thread_id\n"
+         << "Self time : Time accrued by region itself. (Exclusive time.)\n"
+         << "Total time: Time including cost of child routines and profiling "
+            "overheads. (Inclusive time.)\n"
+         << "Overhead  : Profiling overhead incurred through direct child "
+            "routine calls only.\n"
+         << "Calls     : Number of times the region is called.\n";
 
   // Write headings
   os << "\n";
-  os << std::setw(40) << std::left << "Region " << std::setw(15) << std::right
-     << "Self (s) " << std::setw(15) << std::right << "Total (s) "
-     << std::setw(15) << std::right << "Overhead (s) " << std::setw(10)
+  os << std::setw(45) << std::left << "Region" << std::setw(15) << std::right
+     << "Self (s)" << std::setw(15) << std::right << "Total (s)"
+     << std::setw(15) << std::right << "Overhead (s)" << std::setw(10)
      << std::right << "Calls\n";
 
   os << std::setfill('-');
-  os << std::setw(40) << "- " << std::setw(15) << "- " << std::setw(15) << "- "
-     << std::setw(15) << "- " << std::setw(10) << "- \n";
+  os << std::left;
+  os << std::setw(45) << "" << std::setw(15) << " " << std::setw(15) << " "
+     << std::setw(15) << " " << std::setw(10) << " " << std::endl;
   os << std::setfill(' ');
 
   // Data entries
   for (auto const &record : hashvec) {
-    os << std::setw(40) << std::left << record.decorated_region_name_ << " "
-       << std::setw(15) << std::right << record.self_walltime_.count() << " "
-       << std::setw(15) << std::right << record.total_walltime_.count() << " "
+    os << std::setw(45) << std::left << record.decorated_region_name_
+       << std::setw(15) << std::right << record.self_walltime_.count()
+       << std::setw(15) << std::right << record.total_walltime_.count()
        << std::setw(15) << std::right << record.overhead_walltime_.count()
-       << " " << std::setw(10) << std::right << record.call_count_ << "\n";
+       << std::setw(10) << std::right << record.call_count_ << "\n";
   }
 }
 
@@ -104,7 +105,8 @@ void meto::Formatter::threads(std::ostream &os, hashvec_t hashvec) {
  * @param[in] hashvec  Vector containing all the necessary data
  */
 
-void meto::Formatter::drhook(std::ostream &os, hashvec_t hashvec) {
+void meto::Formatter::drhook(std::ostream &header, std::ostream &os,
+                             const hashvec_t &hashvec) {
 
   int num_threads = 1;
 #ifdef _OPENMP

--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -65,7 +65,7 @@ void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,
 void meto::Formatter::default_output(std::ostream &header, std::ostream &os,
                                      const hashvec_t &hashvec) {
 
-  // Write key
+  // Write header
   header << "\n";
   header << "region_name@thread_id\n"
          << "Self time : Time accrued by region itself. (Exclusive time.)\n"

--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -44,9 +44,9 @@ meto::Formatter::Formatter() {
 /**
  * @brief  Executes the format_ method to write the data.
  *
- * @param[in] header   Output stream for the format header
- * @param[in] os       Output stream that the format method will write data to
- * @param[in] hashvec  Vector of data that the format method will operate on
+ * @param[inout] header   Output stream for the format header
+ * @param[inout] os       Output stream that the format method will write data to
+ * @param[in]    hashvec  Vector of data that the format method will operate on
  */
 
 void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,
@@ -57,8 +57,9 @@ void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,
 /**
  * @brief  Per-thread timing output.
  *
- * @param[in] os       Output stream to write to
- * @param[in] hashvec  Vector containing all the necessary data
+ * @param[inout] header   Output stream for the format header
+ * @param[inout] os       Output stream to write to
+ * @param[in]    hashvec  Vector containing all the necessary data
  */
 
 void meto::Formatter::default_output(std::ostream &header, std::ostream &os,

--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -98,21 +98,21 @@ void meto::Formatter::default_output(std::ostream &header, std::ostream &os,
 }
 
 /**
- * @brief  Drhook-style output format, important for using the same post
+ * @brief  Drhook-style output format, important for using the same post-
  *         processing tools
  *
+ * @param header       Header stream to write to
  * @param[in] os       Output stream to write to
  * @param[in] hashvec  Vector containing all the necessary data
  */
 
-void meto::Formatter::drhook(std::ostream &header, std::ostream &os,
-                             const hashvec_t &hashvec) {
+void meto::Formatter::drhook([[maybe_unused]] std::ostream &header,
+                             std::ostream &os, const hashvec_t &hashvec) {
 
   int num_threads = 1;
 #ifdef _OPENMP
   num_threads = omp_get_max_threads();
 #endif
-
   // Preliminary info
   os << "Profiling on " << num_threads << " thread(s).\n";
 

--- a/src/c++/formatter.cpp
+++ b/src/c++/formatter.cpp
@@ -62,7 +62,7 @@ void meto::Formatter::execute_format(std::ostream &header, std::ostream &os,
  */
 
 void meto::Formatter::default_output(std::ostream &header, std::ostream &os,
-                              const hashvec_t &hashvec) {
+                                     const hashvec_t &hashvec) {
 
   // Write key
   header << "\n";

--- a/src/c++/formatter.h
+++ b/src/c++/formatter.h
@@ -44,7 +44,7 @@ private:
 
   // Individual formatter functions
   void default_output(std::ostream &header, std::ostream &os,
-               const hashvec_t &hashvec);
+                      const hashvec_t &hashvec);
   void drhook(std::ostream &header, std::ostream &os, const hashvec_t &hashvec);
 
 public:
@@ -55,7 +55,7 @@ public:
   void execute_format(std::ostream &header, std::ostream &os,
                       const hashvec_t &hashvec);
 
-  [[nodiscard]] std::string  get_format_string() const { return format_string_; }
+  [[nodiscard]] std::string get_format_string() const { return format_string_; }
 };
 
 } // namespace meto

--- a/src/c++/formatter.h
+++ b/src/c++/formatter.h
@@ -37,19 +37,25 @@ namespace meto {
 class Formatter {
 
 private:
+  std::string format_string_;
   // Format method
-  void (Formatter::*format_)(std::ostream &, hashvec_t);
+  void (Formatter::*format_)(std::ostream &header, std::ostream &os,
+                             const hashvec_t &hashvec);
 
   // Individual formatter functions
-  void threads(std::ostream &os, hashvec_t);
-  void drhook(std::ostream &os, hashvec_t);
+  void default_output(std::ostream &header, std::ostream &os,
+               const hashvec_t &hashvec);
+  void drhook(std::ostream &header, std::ostream &os, const hashvec_t &hashvec);
 
 public:
   // Constructor
   explicit Formatter();
 
   // Execute the format method
-  void execute_format(std::ostream &os, hashvec_t, MPIContext &);
+  void execute_format(std::ostream &header, std::ostream &os,
+                      const hashvec_t &hashvec);
+
+  [[nodiscard]] std::string  get_format_string() const { return format_string_; }
 };
 
 } // namespace meto

--- a/src/c++/writer/multi.cpp
+++ b/src/c++/writer/multi.cpp
@@ -5,7 +5,9 @@
  * -----------------------------------------------------------------------------
  */
 
+#include <sstream>
 #include "multi.h"
+#include "writer_utils.h"
 
 /**
  * @brief  Construct a new Multi writer.
@@ -36,8 +38,17 @@ void meto::Multi::open_files() {
  */
 
 void meto::Multi::write(hashvec_t hashvec) {
+
+  // Write data into buffers
+  std::ostringstream header_buffer;
+  std::ostringstream data_buffer;
+  rank_info(data_buffer, mpi_context_);
+  header(header_buffer, formatter_.get_format_string());
+  formatter_.execute_format(header_buffer, data_buffer, hashvec);
+
+  // Open file and write buffers
   open_files();
-  formatter_.execute_format(os, hashvec, mpi_context_);
+  os << header_buffer.str() << data_buffer.str();
   os.flush();
   os.close();
 }

--- a/src/c++/writer/multi.cpp
+++ b/src/c++/writer/multi.cpp
@@ -48,7 +48,6 @@ void meto::Multi::write(hashvec_t hashvec) {
 
   // Open file and write buffers
   open_files();
-  os << header_buffer.str() << data_buffer.str();
   os.flush();
   os.close();
 }

--- a/src/c++/writer/multi.cpp
+++ b/src/c++/writer/multi.cpp
@@ -48,6 +48,7 @@ void meto::Multi::write(hashvec_t hashvec) {
 
   // Open file and write buffers
   open_files();
+  os << header_buffer.str() << data_buffer.str();
   os.flush();
   os.close();
 }

--- a/src/c++/writer/multi.cpp
+++ b/src/c++/writer/multi.cpp
@@ -5,9 +5,9 @@
  * -----------------------------------------------------------------------------
  */
 
-#include <sstream>
 #include "multi.h"
 #include "writer_utils.h"
+#include <sstream>
 
 /**
  * @brief  Construct a new Multi writer.

--- a/src/c++/writer/single.cpp
+++ b/src/c++/writer/single.cpp
@@ -61,7 +61,6 @@ void meto::SingleFile::write(hashvec_t hashvec) {
 
   // Broadcast the header length from rank 0 so all ranks know the offset
   int header_length = static_cast<int>(header_buffer.str().length());
-  MPI_Bcast(&header_length, 1, MPI_INT, 0, mpi_context_.get_handle());
 
   // Global maximum string size is required on every task to set up
   // the custom data type

--- a/src/c++/writer/single.cpp
+++ b/src/c++/writer/single.cpp
@@ -34,10 +34,8 @@ void meto::SingleFile::write(hashvec_t hashvec) {
   rank_info(data_buffer, mpi_context_);
   header(header_buffer, formatter_.get_format_string());
 
-  std::cout << header_buffer.str() << std::endl;
   // Format the report on each task and buffer it on each task
   formatter_.execute_format(header_buffer, data_buffer, hashvec);
-  std::cout << header_buffer.str() << std::endl;
 
   std::string filename = output_filename_ + mpi_filename_tail;
 

--- a/src/c++/writer/single.cpp
+++ b/src/c++/writer/single.cpp
@@ -28,7 +28,7 @@ void meto::SingleFile::write(hashvec_t hashvec) {
    * everything through MPI IO.
    */
   std::ostringstream header_buffer; // Formatted header output
-  std::ostringstream data_buffer; // Formatted data output
+  std::ostringstream data_buffer;   // Formatted data output
   std::string mpi_filename_tail = "-collated";
 
   rank_info(data_buffer, mpi_context_);
@@ -92,7 +92,7 @@ void meto::SingleFile::write(hashvec_t hashvec) {
   // Offset each rank's data past the header
   displacement = static_cast<MPI_Offset>(header_length +
                                          mpi_context_.get_rank() * max_length *
-                                         static_cast<int>(sizeof(char)));
+                                             static_cast<int>(sizeof(char)));
   MPI_File_set_view(file_handle, displacement, MPI_CHAR, mpi_buffer, "native",
                     MPI_INFO_NULL);
 

--- a/src/c++/writer/single.cpp
+++ b/src/c++/writer/single.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "single.h"
+#include "writer_utils.h"
+
+#include <iostream>
 
 /**
  * @brief  Construct a new single file writer.
@@ -24,11 +27,17 @@ void meto::SingleFile::write(hashvec_t hashvec) {
   /* This is a complete cheat for now: ignore the ofstream and do
    * everything through MPI IO.
    */
-  std::ostringstream buffer; // Formatted output
+  std::ostringstream header_buffer; // Formatted header output
+  std::ostringstream data_buffer; // Formatted data output
   std::string mpi_filename_tail = "-collated";
 
+  rank_info(data_buffer, mpi_context_);
+  header(header_buffer, formatter_.get_format_string());
+
+  std::cout << header_buffer.str() << std::endl;
   // Format the report on each task and buffer it on each task
-  formatter_.execute_format(buffer, hashvec, mpi_context_);
+  formatter_.execute_format(header_buffer, data_buffer, hashvec);
+  std::cout << header_buffer.str() << std::endl;
 
   std::string filename = output_filename_ + mpi_filename_tail;
 
@@ -39,7 +48,7 @@ void meto::SingleFile::write(hashvec_t hashvec) {
    */
   std::ofstream os(filename);
 
-  os << buffer.str();
+  os << header_buffer.str() << data_buffer.str();
   os.flush();
   os.close();
 
@@ -52,14 +61,18 @@ void meto::SingleFile::write(hashvec_t hashvec) {
   MPI_Status status;       // Result of write
   MPI_Offset displacement; // Displacement in bytes on this rank.
 
+  // Broadcast the header length from rank 0 so all ranks know the offset
+  int header_length = static_cast<int>(header_buffer.str().length());
+  MPI_Bcast(&header_length, 1, MPI_INT, 0, mpi_context_.get_handle());
+
   // Global maximum string size is required on every task to set up
   // the custom data type
-  length = static_cast<int>(buffer.str().length());
+  length = static_cast<int>(data_buffer.str().length());
   MPI_Allreduce(&length, &max_length, 1, MPI_INT, MPI_MAX,
                 mpi_context_.get_handle());
 
   // Pad out with spaces
-  buffer << std::string(
+  data_buffer << std::string(
       static_cast<std::string::size_type>(max_length - length), ' ');
 
   MPI_Type_contiguous(max_length, MPI_CHAR, &mpi_buffer);
@@ -70,14 +83,22 @@ void meto::SingleFile::write(hashvec_t hashvec) {
   MPI_File_open(mpi_context_.get_handle(), filename.c_str(),
                 MPI_MODE_CREATE | MPI_MODE_WRONLY, MPI_INFO_NULL, &file_handle);
 
-  displacement = static_cast<MPI_Offset>(mpi_context_.get_rank() * max_length *
+  // Write the header once from rank 0
+  if (mpi_context_.get_rank() == 0) {
+    MPI_File_write(file_handle, header_buffer.str().c_str(), header_length,
+                   MPI_CHAR, &status);
+  }
+
+  // Offset each rank's data past the header
+  displacement = static_cast<MPI_Offset>(header_length +
+                                         mpi_context_.get_rank() * max_length *
                                          static_cast<int>(sizeof(char)));
   MPI_File_set_view(file_handle, displacement, MPI_CHAR, mpi_buffer, "native",
                     MPI_INFO_NULL);
 
   // Collective write operation
   // Some evidence of memory leak risk with MPI_File_write_all.
-  MPI_File_write(file_handle, buffer.str().c_str(), max_length, MPI_CHAR,
+  MPI_File_write(file_handle, data_buffer.str().c_str(), max_length, MPI_CHAR,
                  &status);
 
   // Tidy up resources

--- a/src/c++/writer/writer_utils.h
+++ b/src/c++/writer/writer_utils.h
@@ -1,0 +1,63 @@
+/*----------------------------------------------------------------------------*\
+ (c) Crown copyright 2026 Met Office. All rights reserved.
+ The file LICENCE, distributed with this code, contains details of the terms
+ under which the code may be used.
+--------------------------------------------------------------------------------
+ Utility functions for use in the writer classes
+\*----------------------------------------------------------------------------*/
+
+#ifndef VERNIER_WRITER_UTILS_H
+#define VERNIER_WRITER_UTILS_H
+
+#include <iomanip>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+#include "mpi_context.h"
+
+/**
+ * @brief Prints the MPI rank information to the output stream.
+ */
+inline void rank_info(std::ostream &os, meto::MPIContext &mpi_context) {
+  os << "\n"
+     << "Task " << (mpi_context.get_rank() + 1) << " of "
+     << mpi_context.get_size() << " : MPI rank ID " << mpi_context.get_rank()
+     << "\n";
+}
+
+/**
+ * @brief Prints the format version to the output stream.
+ */
+inline void format_version(std::ostream &os) {
+  int major = 1;
+  int minor = 0;
+  os << "Format version: " << std::to_string(major) << "."
+     << std::to_string(minor);
+}
+
+/**
+ * @brief Prints a header to the output stream, including the output style and
+ * format version.
+ */
+inline void header(std::ostream &os, const std::string_view style) {
+
+  // Build the variable-width content strings
+  std::string style_line = "   Output style: " + std::string(style);
+
+  std::ostringstream ver_stream;
+  format_version(ver_stream);
+  std::string version_line = "   " + ver_stream.str();
+
+  // Fixed-width line content (98 chars between the '#' borders)
+  const int inner_width = 98;
+
+  os << std::setfill('#') << std::setw(100) << "" << "\n"
+     << "#" << std::setfill(' ') << std::setw(inner_width) << std::left
+     << "   V E R N I E R" << "#\n"
+     << "#" << std::setw(inner_width) << std::left << style_line << "#\n"
+     << "#" << std::setw(inner_width) << std::left << version_line << "#\n"
+     << std::setfill('#') << std::setw(100) << "" << "\n";
+}
+
+#endif // VERNIER_WRITER_UTILS_H

--- a/src/c++/writer/writer_utils.h
+++ b/src/c++/writer/writer_utils.h
@@ -52,15 +52,12 @@ inline void header(std::ostream &os, const std::string_view style) {
   // Fixed-width line content (98 chars between the '#' borders)
   const int inner_width = 98;
 
-  os << std::setfill('#') << std::setw(100) << ""
-     << "\n"
+  os << std::setfill('#') << std::setw(100) << "" << "\n"
      << "#" << std::setfill(' ') << std::setw(inner_width) << std::left
-     << "   V E R N I E R"
-     << "#\n"
+     << "   V E R N I E R" << "#\n"
      << "#" << std::setw(inner_width) << std::left << style_line << "#\n"
      << "#" << std::setw(inner_width) << std::left << version_line << "#\n"
-     << std::setfill('#') << std::setw(100) << ""
-     << "\n";
+     << std::setfill('#') << std::setw(100) << "" << "\n";
 }
 
 #endif // VERNIER_WRITER_UTILS_H

--- a/src/c++/writer/writer_utils.h
+++ b/src/c++/writer/writer_utils.h
@@ -52,12 +52,15 @@ inline void header(std::ostream &os, const std::string_view style) {
   // Fixed-width line content (98 chars between the '#' borders)
   const int inner_width = 98;
 
-  os << std::setfill('#') << std::setw(100) << "" << "\n"
+  os << std::setfill('#') << std::setw(100) << ""
+     << "\n"
      << "#" << std::setfill(' ') << std::setw(inner_width) << std::left
-     << "   V E R N I E R" << "#\n"
+     << "   V E R N I E R"
+     << "#\n"
      << "#" << std::setw(inner_width) << std::left << style_line << "#\n"
      << "#" << std::setw(inner_width) << std::left << version_line << "#\n"
-     << std::setfill('#') << std::setw(100) << "" << "\n";
+     << std::setfill('#') << std::setw(100) << ""
+     << "\n";
 }
 
 #endif // VERNIER_WRITER_UTILS_H

--- a/tests/system_tests/c++/CMakeLists.txt
+++ b/tests/system_tests/c++/CMakeLists.txt
@@ -5,39 +5,51 @@
 # ------------------------------------------------------------------------------
 
 if (BUILD_TESTS)
-
-  #
-  # Add MPI to parallel libraries if required.
-  #
-
-  set (PLIBS OpenMP::OpenMP_CXX)
-
-  if (ENABLE_MPI)
-    list(APPEND PLIBS MPI::MPI_CXX)
-  endif()
-
-  # Function to simplify adding system-tests
-  function(add_cxx_system_test test_name source_file ranks)
-    set(TESTNAME_PREFIX "SystemTests")
-    message(STATUS "Building ${TESTNAME_PREFIX}.${test_name}")
-    add_executable(${TESTNAME_PREFIX}_${test_name} ${source_file})
-    target_link_libraries(${TESTNAME_PREFIX}_${test_name} ${CMAKE_PROJECT_NAME} ${PLIBS}) 
-    target_include_directories(${TESTNAME_PREFIX}_${test_name} PUBLIC ${CMAKE_BINARY_DIR}/src/c++)
-    if (NOT ENABLE_MPI)
-      target_compile_definitions(${TESTNAME_PREFIX}_${test_name} PRIVATE USE_VERNIER_MPI_STUB)
-    endif()
-    set_project_warnings(${TESTNAME_PREFIX}_${test_name})
-    add_test(NAME ${TESTNAME_PREFIX}_${test_name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND ${MPITEST_EXECUTABLE_NAME} ${MPIEXEC_NUMPROC_FLAG} ${ranks} $<TARGET_FILE:${TESTNAME_PREFIX}_${test_name}>
+    add_custom_target(copy_data
+            COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_data
+                ${CMAKE_CURRENT_BINARY_DIR}/test_data
+            COMMENT "Copying system test data files to build directory"
     )
-  endfunction()
+    set(COPY_DATA_DEPS)
+    #
+    # Add MPI to parallel libraries if required.
+    #
 
-  add_cxx_system_test(TestTags test-tags.cpp 1)
-  add_cxx_system_test(TestOutputs test-output-files.cpp 1)
+    set(PLIBS OpenMP::OpenMP_CXX)
 
-  if (ENABLE_MPI)
-    add_cxx_system_test(TestVernierMPIHeaders test-vernier-mpi-headers.cpp 2)
-    add_cxx_system_test(TestMPIOutputs test-output-files.cpp 2)
-  endif()
-endif ()
+    if (ENABLE_MPI)
+        list(APPEND PLIBS MPI::MPI_CXX)
+    endif ()
+
+    # Function to simplify adding system-tests
+    function(add_cxx_system_test test_name source_file ranks copy_data)
+        set(TESTNAME_PREFIX "SystemTests")
+        message(STATUS "Building ${TESTNAME_PREFIX}.${test_name}")
+        add_executable(${TESTNAME_PREFIX}_${test_name} ${source_file})
+        target_link_libraries(${TESTNAME_PREFIX}_${test_name} ${CMAKE_PROJECT_NAME} ${PLIBS})
+        target_include_directories(${TESTNAME_PREFIX}_${test_name} PUBLIC ${CMAKE_BINARY_DIR}/src/c++)
+        if (NOT ENABLE_MPI)
+            target_compile_definitions(${TESTNAME_PREFIX}_${test_name} PRIVATE USE_VERNIER_MPI_STUB)
+        endif ()
+        set_project_warnings(${TESTNAME_PREFIX}_${test_name})
+        add_test(NAME ${TESTNAME_PREFIX}_${test_name}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                COMMAND ${MPITEST_EXECUTABLE_NAME} ${MPIEXEC_NUMPROC_FLAG} ${ranks} $<TARGET_FILE:${TESTNAME_PREFIX}_${test_name}>
+        )
+        if (copy_data)
+            set(COPY_DATA_DEPS
+                "${COPY_DATA_DEPS};${TESTNAME_PREFIX}_${test_name}"
+                PARENT_SCOPE)
+        endif ()
+    endfunction()
+
+    add_cxx_system_test(TestTags test-tags.cpp 1 FALSE)
+    add_cxx_system_test(TestOutputs test-output-files.cpp 1 TRUE)
+
+    if (ENABLE_MPI)
+        add_cxx_system_test(TestVernierMPIHeaders test-vernier-mpi-headers.cpp 2 TRUE)
+        add_cxx_system_test(TestMPIOutputs test-output-files.cpp 2 TRUE)
+    endif ()
+    add_dependencies(${COPY_DATA_DEPS} copy_data)
+    endif ()

--- a/tests/system_tests/c++/test-output-files.cpp
+++ b/tests/system_tests/c++/test-output-files.cpp
@@ -12,54 +12,54 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <string>
+
+// Define a simple assertion macro that prints the expected and actual values on
+// failure.
+#define M_Assert(expected, value, file_line)                                   \
+  __M_Assert(expected, value, file_line, __FILE__, __LINE__)
+
+void __M_Assert(const std::string &expected, const std::string &value,
+                const int file_line, const char *file, const int line) {
+  if (expected != value) {
+    std::cerr << "Error: " << file << ":" << line << std::endl
+              << "Assertion failed: source line: " << line
+              << " against KGO file line: " << file_line << std::endl
+              << "Expected: " << expected << std::endl
+              << "Received: " << value << std::endl;
+
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+}
 
 /*
  * Check the first few lines of the output file
  */
-bool check_output_file(std::string path, std::string format) {
-  std::filebuf fb;
+bool check_output_file(const std::string &output_data_path,
+                       const std::string &test_data_path) {
+  std::filebuf output_file_buffer;
+  std::filebuf test_file_buffer;
   std::string buffer;
   std::string expected;
 
-  if (!fb.open(path, std::ios::in)) {
-    std::cerr << "failed to open " << path << std::endl;
+  if (!test_file_buffer.open(test_data_path, std::ios::in)) {
+    std::cerr << "failed to open " << test_data_path << std::endl;
     return false;
   }
+  std::istream test_data(&test_file_buffer);
 
-  std::istream input(&fb);
+  if (!output_file_buffer.open(output_data_path, std::ios::in)) {
+    std::cerr << "failed to open " << output_data_path << std::endl;
+    return false;
+  }
+  std::istream input(&output_file_buffer);
 
   // Check the header lines
-  std::getline(input, buffer);
-  if (buffer.compare("") != 0) {
-    std::cerr << "Invalid line: " << buffer << std::endl;
-    return false;
-  }
-
-  std::getline(input, buffer);
-  if (buffer.compare(0, 9, "Task 1 of") != 0) {
-    std::cerr << "Invalid line: " << buffer << std::endl;
-    return false;
-  }
-
-  // Match the next line to the start of an output format
-  if (format.compare("drhook") == 0) {
-    expected = "Profiling on ";
-  } else if (format.compare("threads") == 0) {
-    // Skip extra blank line in threads format
+  for (int i = 0; i < 8; ++i) {
     std::getline(input, buffer);
-    expected = "region_name@thread_id";
-  } else {
-    std::cerr << "unknown format" << std::endl;
-    return false;
-  }
-
-  std::getline(input, buffer);
-  if (buffer.compare(0, expected.length(), expected) != 0) {
-    std::cerr << "Invalid next line" << std::endl;
-    std::cerr << "Got:      " << buffer << std::endl;
-    std::cerr << "Expected: " << expected << std::endl;
-    return false;
+    std::getline(test_data, expected);
+    M_Assert(expected, buffer, i);
   }
 
   return true;
@@ -68,10 +68,11 @@ bool check_output_file(std::string path, std::string format) {
 /*
  * Generate some profiler output and check the contents
  */
-bool create_output(std::string mode, std::string format, int rank) {
-  std::string path = format + "-vernier-output";
+bool create_output(std::string mode, std::string format, int rank,
+                   int total_ranks) {
+  std::string path = format + "-" + std::to_string(total_ranks) + "core-vernier-output";
   meto::vernier.init(MPI_COMM_WORLD);
-
+  std::string test_data_path = "test_data/" + format + "-" + std::to_string(total_ranks) + "core-" + mode;
   // Create some data
   auto vnr_handle = meto::vernier.start("main");
 
@@ -105,7 +106,7 @@ bool create_output(std::string mode, std::string format, int rank) {
     return false;
   }
 
-  if (rank == 0 && !check_output_file(path, format)) {
+  if (rank == 0 && !check_output_file(path, test_data_path)) {
     std::cerr << mode << " file " << format << " test failed" << std::endl;
     return false;
   }
@@ -118,15 +119,17 @@ bool create_output(std::string mode, std::string format, int rank) {
  */
 int main() {
   int rank;
+  int total_ranks;
   std::string modes[] = {"multi", "single"};
-  std::string formats[] = {"drhook", "threads"};
+  std::string formats[] = {"drhook", "default"};
 
   MPI_Init(NULL, NULL);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
 
   for (auto mode : modes) {
     for (auto format : formats) {
-      if (!create_output(mode, format, rank)) {
+      if (!create_output(mode, format, rank, total_ranks)) {
         MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
       }
     }

--- a/tests/system_tests/c++/test-output-files.cpp
+++ b/tests/system_tests/c++/test-output-files.cpp
@@ -56,7 +56,7 @@ bool check_output_file(const std::string &output_data_path,
   std::istream input(&output_file_buffer);
 
   // Check the header lines
-  for (int i = 0; i < 13; ++i) {
+  for (int i = 0; i < 8; ++i) {
     std::getline(input, buffer);
     std::getline(test_data, expected);
     M_Assert(expected, buffer, i);

--- a/tests/system_tests/c++/test-output-files.cpp
+++ b/tests/system_tests/c++/test-output-files.cpp
@@ -70,9 +70,11 @@ bool check_output_file(const std::string &output_data_path,
  */
 bool create_output(std::string mode, std::string format, int rank,
                    int total_ranks) {
-  std::string path = format + "-" + std::to_string(total_ranks) + "core-vernier-output";
+  std::string path =
+      format + "-" + std::to_string(total_ranks) + "core-vernier-output";
   meto::vernier.init(MPI_COMM_WORLD);
-  std::string test_data_path = "test_data/" + format + "-" + std::to_string(total_ranks) + "core-" + mode;
+  std::string test_data_path = "test_data/" + format + "-" +
+                               std::to_string(total_ranks) + "core-" + mode;
   // Create some data
   auto vnr_handle = meto::vernier.start("main");
 

--- a/tests/system_tests/c++/test-output-files.cpp
+++ b/tests/system_tests/c++/test-output-files.cpp
@@ -56,7 +56,7 @@ bool check_output_file(const std::string &output_data_path,
   std::istream input(&output_file_buffer);
 
   // Check the header lines
-  for (int i = 0; i < 8; ++i) {
+  for (int i = 0; i < 13; ++i) {
     std::getline(input, buffer);
     std::getline(test_data, expected);
     M_Assert(expected, buffer, i);

--- a/tests/system_tests/c++/test-output-files.cpp
+++ b/tests/system_tests/c++/test-output-files.cpp
@@ -56,7 +56,7 @@ bool check_output_file(const std::string &output_data_path,
   std::istream input(&output_file_buffer);
 
   // Check the header lines
-  for (int i = 0; i < 8; ++i) {
+  for (int i = 0; i < 7; ++i) {
     std::getline(input, buffer);
     std::getline(test_data, expected);
     M_Assert(expected, buffer, i);

--- a/tests/system_tests/c++/test_data/default-1core-multi
+++ b/tests/system_tests/c++/test_data/default-1core-multi
@@ -1,0 +1,19 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Default                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+region_name@thread_id
+Self time : Time accrued by region itself. (Exclusive time.)
+Total time: Time including cost of child routines and profiling overheads. (Inclusive time.)
+Overhead  : Profiling overhead incurred through direct child routine calls only.
+Calls     : Number of times the region is called.
+
+Task 1 of 1 : MPI rank ID 0
+
+Region                                              Self (s)      Total (s)   Overhead (s)    Calls
+--------------------------------------------- -------------- -------------- -------------- ---------
+__vernier__@0                                    1.11202e-05    1.11202e-05              0         2
+main@0                                           4.51924e-07    3.47686e-06      2.885e-06         1
+even_rank@0                                      1.39931e-07    1.39931e-07              0         1

--- a/tests/system_tests/c++/test_data/default-1core-single
+++ b/tests/system_tests/c++/test_data/default-1core-single
@@ -1,0 +1,19 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Default                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+region_name@thread_id
+Self time : Time accrued by region itself. (Exclusive time.)
+Total time: Time including cost of child routines and profiling overheads. (Inclusive time.)
+Overhead  : Profiling overhead incurred through direct child routine calls only.
+Calls     : Number of times the region is called.
+
+Task 1 of 1 : MPI rank ID 0
+
+Region                                              Self (s)      Total (s)   Overhead (s)    Calls
+--------------------------------------------- -------------- -------------- -------------- ---------
+__vernier__@0                                    9.49879e-06    9.49879e-06              0         2
+main@0                                           4.71016e-07    3.51691e-06    2.90573e-06         1
+even_rank@0                                      1.40164e-07    1.40164e-07              0         1

--- a/tests/system_tests/c++/test_data/default-2core-multi
+++ b/tests/system_tests/c++/test_data/default-2core-multi
@@ -1,0 +1,19 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Default                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+region_name@thread_id
+Self time : Time accrued by region itself. (Exclusive time.)
+Total time: Time including cost of child routines and profiling overheads. (Inclusive time.)
+Overhead  : Profiling overhead incurred through direct child routine calls only.
+Calls     : Number of times the region is called.
+
+Task 1 of 2 : MPI rank ID 0
+
+Region                                              Self (s)      Total (s)   Overhead (s)    Calls
+--------------------------------------------- -------------- -------------- -------------- ---------
+__vernier__@0                                    1.92672e-05    1.92672e-05              0         2
+main@0                                           5.40866e-07    4.28804e-06    3.59723e-06         1
+even_rank@0                                      1.49943e-07    1.49943e-07              0         1

--- a/tests/system_tests/c++/test_data/default-2core-single
+++ b/tests/system_tests/c++/test_data/default-2core-single
@@ -1,0 +1,26 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Default                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+region_name@thread_id
+Self time : Time accrued by region itself. (Exclusive time.)
+Total time: Time including cost of child routines and profiling overheads. (Inclusive time.)
+Overhead  : Profiling overhead incurred through direct child routine calls only.
+Calls     : Number of times the region is called.
+
+Task 1 of 2 : MPI rank ID 0
+
+Region                                              Self (s)      Total (s)   Overhead (s)    Calls
+--------------------------------------------- -------------- -------------- -------------- ---------
+__vernier__@0                                    1.21628e-05    1.21628e-05              0         2
+main@0                                           4.90109e-07    3.98699e-06    3.32599e-06         1
+even_rank@0                                      1.70898e-07    1.70898e-07              0         1
+
+Task 2 of 2 : MPI rank ID 1
+
+Region                                              Self (s)      Total (s)   Overhead (s)    Calls
+--------------------------------------------- -------------- -------------- -------------- ---------
+__vernier__@0                                    3.56771e-05    3.56771e-05              0         1
+main@0                                           3.69968e-07    3.69968e-07              0         1

--- a/tests/system_tests/c++/test_data/drhook-1core-multi
+++ b/tests/system_tests/c++/test_data/drhook-1core-multi
@@ -1,0 +1,16 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Dr HOOK                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+Task 1 of 1 : MPI rank ID 0
+Profiling on 4 thread(s).
+
+    #  % Time         Cumul         Self        Total     # of calls        Self   Total    Routine@
+                                                                             (Size; Size/sec; Size/call; MinSize; MaxSize)
+        (self)        (sec)        (sec)        (sec)                    ms/call   ms/call
+
+    1  100.000        0.000        0.000        0.000              2       0.015       0.015    __vernier__@0
+    2    7.624        0.000        0.000        0.000              1       0.002       0.011    main@0
+    3    2.360        0.000        0.000        0.000              1       0.001       0.001    even_rank@0

--- a/tests/system_tests/c++/test_data/drhook-1core-single
+++ b/tests/system_tests/c++/test_data/drhook-1core-single
@@ -1,0 +1,16 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Dr HOOK                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+Task 1 of 1 : MPI rank ID 0
+Profiling on 4 thread(s).
+
+    #  % Time         Cumul         Self        Total     # of calls        Self   Total    Routine@
+                                                                             (Size; Size/sec; Size/call; MinSize; MaxSize)
+        (self)        (sec)        (sec)        (sec)                    ms/call   ms/call
+
+    1  100.000        0.000        0.000        0.000              2       0.006       0.006    __vernier__@0
+    2    4.062        0.000        0.000        0.000              1       0.000       0.004    main@0
+    3    1.361        0.000        0.000        0.000              1       0.000       0.000    even_rank@0

--- a/tests/system_tests/c++/test_data/drhook-2core-multi
+++ b/tests/system_tests/c++/test_data/drhook-2core-multi
@@ -1,0 +1,16 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Dr HOOK                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+Task 1 of 2 : MPI rank ID 0
+Profiling on 4 thread(s).
+
+    #  % Time         Cumul         Self        Total     # of calls        Self   Total    Routine@
+                                                                             (Size; Size/sec; Size/call; MinSize; MaxSize)
+        (self)        (sec)        (sec)        (sec)                    ms/call   ms/call
+
+    1  100.000        0.000        0.000        0.000              2       0.014       0.014    __vernier__@0
+    2    7.270        0.000        0.000        0.000              1       0.002       0.010    main@0
+    3    2.475        0.000        0.000        0.000              1       0.001       0.001    even_rank@0

--- a/tests/system_tests/c++/test_data/drhook-2core-single
+++ b/tests/system_tests/c++/test_data/drhook-2core-single
@@ -1,0 +1,26 @@
+####################################################################################################
+#   V E R N I E R                                                                                  #
+#   Output style: Dr HOOK                                                                          #
+#   Format version: 1.0                                                                            #
+####################################################################################################
+
+Task 1 of 2 : MPI rank ID 0
+Profiling on 4 thread(s).
+
+    #  % Time         Cumul         Self        Total     # of calls        Self   Total    Routine@
+                                                                             (Size; Size/sec; Size/call; MinSize; MaxSize)
+        (self)        (sec)        (sec)        (sec)                    ms/call   ms/call
+
+    1  100.000        0.000        0.000        0.000              2       0.006       0.006    __vernier__@0
+    2    3.794        0.000        0.000        0.000              1       0.000       0.003    main@0
+    3    1.153        0.000        0.000        0.000              1       0.000       0.000    even_rank@0
+
+Task 2 of 2 : MPI rank ID 1
+Profiling on 4 thread(s).
+
+    #  % Time         Cumul         Self        Total     # of calls        Self   Total    Routine@
+                                                                             (Size; Size/sec; Size/call; MinSize; MaxSize)
+        (self)        (sec)        (sec)        (sec)                    ms/call   ms/call
+
+    1  100.000        0.000        0.000        0.000              1       0.039       0.039    __vernier__@0
+    2    0.819        0.000        0.000        0.000              1       0.000       0.000    main@0


### PR DESCRIPTION
# Description

<!-- 
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. 
If there is additional detail included in the linked issue please note that here so a reviewer knows to check.      
-->

I've restructured the header output so that it only outputs it once per file (where it used to put the header for each of the ranks in the collated files). The header now includes the output style and the format version which can be picked up by the post-processing apps to check they are working against a format they can deal with. Whilst making these changes I've restructured the `test-output-files` system tests to both check against known good output (this checks the header only (the first 13 lines) as the time values may change, this should be extended in future but will require more complex output parsing) and names the files uniquely based on the total number of cores being tested on (this avoids a race condition in that the 1 and 2 core tests were naming their output files the same but the files had differing content).

## Linked issues

Closes # (issue) <!-- Can be of the following forms Close/s/d #123 Fix/es/ed #123 or Resolve/s/d #123 (e.g. Closes #123) -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] New tests have been added
- [x] Tests have been modified to accommodate this change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes, for both debug and optimised builds

